### PR TITLE
Bump reviewdog to 0.17.1 for new github-pr-annotations reporter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.16
 
-ENV REVIEWDOG_VERSION=v0.15.0
+ENV REVIEWDOG_VERSION=v0.17.1
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 


### PR DESCRIPTION
This bumps the reviewdog version from 0.15.0 to 0.17.1 as while it's been a few releases behind, it would be helpful to have access to the [new github-pr-annotations reporter from the 0.17.0 release](https://github.com/reviewdog/reviewdog/pull/1623) which helps [resolve a longstanding reviewdog issue](https://github.com/reviewdog/reviewdog/issues/403). I made the same change to https://github.com/reviewdog/action-brakeman/pull/52 since a few actions have fallen behind recently.